### PR TITLE
chore(release-template): drop obsolete Crowdin translation checklist item

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -49,7 +49,6 @@ client| x   |y
 - [ ] Obtain approval from stakeholders.
 ---
 - [ ] All linked issues and pull requests are merged.
-- [ ] Client is updated with the latest Crowdin translation (if applicable)
 - [ ] The pre-deployment checklist is done.
 - [ ] Release is deployed to Acceptance.
 - [ ] The post-deployment checklist is done.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the release checklist by removing the outdated translation-update reminder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->