### PR TITLE
docs(dco): replace CLA-signing instructions with DCO 1.1 sign-off

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -1,6 +1,6 @@
 The Stichting Alkemio ("Stichting") reserves all rights to the works that belong to the Sitchting published on this GitHub account. Nevertheless, reuse is permitted under the following conditions.
 
-First - The work that is created in the ALkemio project, is available under the EU-PL license; and any outside contributions to it are under an [individual Contributor License Agreement](https://github.com/alkem-io/.github/blob/master/CLA.md) ("CLA") that references this license explicitly.
+First - The work that is created in the ALkemio project, is available under the EU-PL license; and any outside contributions to it from the DCO cut-over date onward are certified under the [Developer Certificate of Origin 1.1](https://developercertificate.org/) ("DCO") through a per-commit `Signed-off-by` trailer. Contributions made before the cut-over were covered by the retired [individual Contributor License Agreement](https://github.com/alkem-io/.github/blob/master/CLA.md) ("CLA"), kept as a historical reference.
 
 However - that does not mean that all (derived) work is solely under that single license. For example - where appropriate certain (open source) modules may be required and included. These will remain under their original Copyright and License (though some may be released under the EU-PL license if they are unsuitable to be contributed back upstream).
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 Here you can find details of requirements for contributing to the project, an overview of key repositories as well as how coordination takes place.
 
 ## Licensing
-All contributors to the project are required to sign a **[Contributor License Agreement (CLA)](https://github.com/alkem-io/.github/blob/master/CLA.md)** to ensure that the contents of the repository are covered from a legal perspective. The CLA process is enforced for all contributions.
+Contributions to the project are made under the **[Developer Certificate of Origin 1.1 (DCO)](https://developercertificate.org/)** to ensure that the contents of the repository are covered from a legal perspective. Every commit must carry a `Signed-off-by` trailer (add it with `git commit -s`); this is enforced as a required check on all pull requests. Historical contributions made before the DCO cut-over remain covered by the retired [Contributor License Agreement](https://github.com/alkem-io/.github/blob/master/CLA.md).
 
 
 ## Repositories


### PR DESCRIPTION
Umbrella-docs slice of the CLA→DCO migration (`workspace#035-dco-migration`, story `alkem-io/infrastructure-operations#2186`).

Two files still instructed contributors to sign the CLA:

- **`docs/contributing.md`** — the *Licensing* section now states contributions are made under [DCO 1.1](https://developercertificate.org/) with a per-commit `Signed-off-by` (`git commit -s`), enforced as a required check. Contributions predating the cut-over remain covered by the retired CLA, which is linked as a historical reference.
- **`LICENSES.md`** — the EUPL paragraph rewritten the same way: outside contributions from the cut-over date are certified under DCO; earlier ones were covered by the CLA.

Docs only. The CLA link is retained deliberately — it points at the retirement notice, so the historical record stays reachable.

---

## Evidence

Full run ledger: [`specs/035-dco-migration/forge-run.md`](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/forge-run.md) · [spec](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/spec.md) · [plan](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/plan.md) · [runbook](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/runbook.md) · [ADR 0008](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/docs/decisions/0008-dco-enforcement-contract.md)

**Review**: 4 dimensions (correctness · spec-compliance · quality · security) over **7 security rounds**. Every round found something real; rounds 4–7 found defects in the *previous round's remediation*. Two criticals were confirmed by adversarial reproduction against live payloads.

**All commits GPG-signed and DCO signed-off** — this feature's own policy applied to itself.

### Residuals the reviewer ruled trackable (not blockers)

| # | Residual | Severity |
|---|---|---|
| S7-1 | A local actor with evidence-write access can forge a rollback bundle **legally indistinguishable** from a genuine one. Not patchable by comparison — a discriminating guard was built, found to break legitimate recovery, and reverted. Interim control: the H4/H6 human gates. | high |
| D1 | remove-CLA evidence not artifact-bound beyond journals + live pinned-DCO verification | medium |
| D6 | Installer lacks a signed-revision provenance anchor | medium |
| D7 | H5 sweep omits immutable check-run id/URL fields | low |

⚠️ **The round-7 remediation is unreviewed** — it landed after the last review's pinned SHAs.

**This PR changes no live GitHub setting.** All enforcement happens at human gates H1a–H8 per the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
